### PR TITLE
支持使用 LITELOADERQQNT_PROFILE 环境变量指定数据保存位置

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -49,7 +49,8 @@ const LiteLoader = {
     path: {
         root: root_path,
         data: data_path,
-        plugins: plugins_path
+        plugins: plugins_path,
+        profile: profile_root
     },
     versions: {
         qqnt: qqnt_package.version,

--- a/src/init.js
+++ b/src/init.js
@@ -8,6 +8,20 @@ const profile_root = process.env.LITELOADERQQNT_PROFILE ? process.env.LITELOADER
 const data_path = path.join(profile_root, "data");
 const plugins_path = path.join(profile_root, "plugins");
 
+// 如果数据目录不存在
+if (!fs.existsSync(profile_root)) {
+    fs.mkdirSync(profile_root, {recursive: true});
+}
+
+// 如果配置文件不存在
+if (!fs.existsSync(path.join(profile_root, "config.json"))) {
+    fs.copyFileSync(
+        path.join(root_path, "config.json"),
+        path.join(profile_root, "config.json"),
+        fs.constants.COPYFILE_EXCL
+    );
+}
+
 const config = require(path.join(profile_root, "config.json"));
 const liteloader_package = require(path.join(root_path, "package.json"));
 const qqnt_package = require(path.join(process.resourcesPath, "app/package.json"))
@@ -49,8 +63,7 @@ const LiteLoader = {
     path: {
         root: root_path,
         data: data_path,
-        plugins: plugins_path,
-        profile: profile_root
+        plugins: plugins_path
     },
     versions: {
         qqnt: qqnt_package.version,

--- a/src/init.js
+++ b/src/init.js
@@ -4,16 +4,17 @@ const fs = require("node:fs");
 
 
 const root_path = path.join(__dirname, "..");
-const data_path = path.join(root_path, "data");
-const plugins_path = path.join(root_path, "plugins");
+const profile_root = process.env.LITELOADERQQNT_PROFILE ? process.env.LITELOADERQQNT_PROFILE : root_path;
+const data_path = path.join(profile_root, "data");
+const plugins_path = path.join(profile_root, "plugins");
 
-const config = require(path.join(root_path, "config.json"));
+const config = require(path.join(profile_root, "config.json"));
 const liteloader_package = require(path.join(root_path, "package.json"));
 const qqnt_package = require(path.join(process.resourcesPath, "app/package.json"))
 
 
 function disablePlugin(slug, disabled) {
-    const config_path = path.join(root_path, "config.json");
+    const config_path = path.join(profile_root, "config.json");
     const config = JSON.parse(fs.readFileSync(config_path, "utf-8"));
     if (disabled) {
         config.LiteLoader.disabled_plugins = config.LiteLoader.disabled_plugins.concat(slug);

--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,19 @@ const loader = new class {
             return;
         }
 
+        // 如果配置文件不存在
+        if (!fs.existsSync(path.join(LiteLoader.path.profile, "config.json"))) {
+            output("No config file found.");
+            output("Copying default config file.")
+            fs.copyFile(
+                path.join(LiteLoader.path.root, "config.json"), path.join(LiteLoader.path.profile, "config.json"),
+                fs.constrants.COPYFILE_EXCL, (error) => {
+                    output("Copy default config failed!");
+                    output("Please check config.json");
+                }
+            );
+        }
+
         // 读取插件目录
         try {
             for (const plugin_pathname of fs.readdirSync(LiteLoader.path.plugins, "utf-8")) {

--- a/src/main.js
+++ b/src/main.js
@@ -29,19 +29,6 @@ const loader = new class {
             return;
         }
 
-        // 如果配置文件不存在
-        if (!fs.existsSync(path.join(LiteLoader.path.profile, "config.json"))) {
-            output("No config file found.");
-            output("Copying default config file.")
-            fs.copyFile(
-                path.join(LiteLoader.path.root, "config.json"), path.join(LiteLoader.path.profile, "config.json"),
-                fs.constrants.COPYFILE_EXCL, (error) => {
-                    output("Copy default config failed!");
-                    output("Please check config.json");
-                }
-            );
-        }
-
         // 读取插件目录
         try {
             for (const plugin_pathname of fs.readdirSync(LiteLoader.path.plugins, "utf-8")) {


### PR DESCRIPTION
对于 Linux 用户来说，如果 LiteLoader 是被系统管理员安装的，那么用户自己可能没有任意读写 LiteLoader 文件夹的权限。使用这个环境变量可以指定一个自己的数据存储位置，如果不设置这个环境变量，应该还是按照以前的样子使用 LiteLoader 文件夹