### PR TITLE
修正 `<setting-select>` 下拉框不跟随页面滚动的问题

### DIFF
--- a/src/components/select.js
+++ b/src/components/select.js
@@ -63,7 +63,8 @@ template.innerHTML = /*html*/ `
     }
 
     ul {
-        position: fixed;
+        position: absolute;
+        top: 100%;
         backdrop-filter: blur(8px);
         display: flex;
         flex-direction: column;
@@ -81,7 +82,6 @@ template.innerHTML = /*html*/ `
         max-height: var(--q-contextmenu-max-height);
         overflow-x: hidden;
         overflow-y: auto;
-        backdrop-filter: blur(8px);
         margin: 5px 0px;
         z-index: 999;
     }


### PR DESCRIPTION
其实只是因为写错了一处 css 导致的

效果：

![QQ_fGw7yAJPAx](https://github.com/LiteLoaderQQNT/LiteLoaderQQNT/assets/62408957/77fae0cd-b59e-4306-a9ae-1c898fa7f8e8)
