### PR TITLE
修复插件列表显示

### DIFF
--- a/src/setting/renderer.js
+++ b/src/setting/renderer.js
@@ -212,7 +212,7 @@ async function initPluginList(view) {
         plugin_item_description.title = plugin.manifest.description;
         plugin_item_version.textContent = plugin.manifest.version;
 
-        plugin.manifest.authors.forEach((author, index, array) => {
+        plugin.manifest.authors?.forEach((author, index, array) => {
             const author_link = document.createElement("a");
             author_link.textContent = author.name;
             author_link.addEventListener("click", () => LiteLoader.api.openExternal(author.link));


### PR DESCRIPTION
缺了个判空，导致如果没有authors整个foreach就崩了

#229 

Before：
![snipaste_20240630_001519](https://github.com/LiteLoaderQQNT/LiteLoaderQQNT/assets/18360825/349ae997-7c50-440a-a1d6-95d50ddd2b28)

After：
![snipaste_20240630_001556](https://github.com/LiteLoaderQQNT/LiteLoaderQQNT/assets/18360825/14e8f81c-0f2f-486c-a4fa-6f4ef99116c4)

