### PR TITLE
修一下偶发的render比preload早的故障

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -1,4 +1,4 @@
-const { ipcRenderer } = require("electron");
+const { ipcRenderer, contextBridge } = require("electron");
 
 
 // 加载渲染进程
@@ -37,10 +37,7 @@ const runPreloadScript = code => binding.createPreloadScript(`
         }
     }
 
-    const errorData = document.createElement("script");
-    errorData.textContent = JSON.stringify(preloadErrors);
-    errorData.id = "LL_PRELOAD_ERRORS";
-    document.head.append(errorData);
+    contextBridge.exposeInMainWorld("LiteLoaderPreloadErrors", preloadErrors);
 })();
 
 


### PR DESCRIPTION
有时候（比如窗口刷新时）插件的renderer会比preload早导致插件找不着北，加了些逻辑以确保preload就绪