### PR TITLE
feat: 添加mainfest.json的json schema校验文件

### DIFF
--- a/manifest-en.schema.json
+++ b/manifest-en.schema.json
@@ -1,0 +1,154 @@
+{
+  "type": "object",
+  "title": "LiteLoader QQ NT Manifest Schema",
+  "description": "Json schema for LiteLoader QQ NT manifest.json.",
+  "required": [
+    "manifest_version",
+    "name",
+    "slug",
+    "description",
+    "version",
+    "authors",
+    "platform"
+  ],
+  "properties": {
+    "manifest_version": {
+      "type": "integer",
+      "description": "Required, current version is 4",
+      "enum": [4],
+      "default": 4
+    },
+    "type": {
+      "type": "string",
+      "description": "Optional, plugin type, can be extension | theme | framework",
+      "enum": ["extension", "theme", "framework"]
+    },
+    "name": {
+      "type": "string",
+      "description": "Required, plugin name"
+    },
+    "slug": {
+      "type": "string",
+      "description": "Required, code identifier"
+    },
+    "description": {
+      "type": "string",
+      "description": "Required, plugin description"
+    },
+    "version": {
+      "type": "string",
+      "description": "Required, version number"
+    },
+    "icon": {
+      "description": "Optional, plugin icon",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "thumb": {
+      "description": "Optional, settings icon, write as a relative path string",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "authors": {
+      "type": "array",
+      "description": "Required, author information",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "link"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Required, author name"
+          },
+          "link": {
+            "type": "string",
+            "description": "Required, author homepage"
+          }
+        }
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "description": "Optional, plugin dependencies, write the plugin slug names",
+      "items": {
+        "type": "string"
+      }
+    },
+    "platform": {
+      "type": "array",
+      "description": "Required, supported platforms, Windows: win32 | Linux: linux | MacOS: darwin",
+      "items": {
+        "type": "string",
+        "enum": ["win32", "linux", "darwin"]
+      }
+    },
+    "injects": {
+      "type": "object",
+      "description": "Optional, scripts to inject",
+      "properties": {
+        "renderer": {
+          "type": "string",
+          "description": "Optional, renderer process injection script"
+        },
+        "main": {
+          "type": "string",
+          "description": "Optional, main process injection script"
+        },
+        "preload": {
+          "type": "string",
+          "description": "Optional, preload injection script"
+        }
+      }
+    },
+    "repository": {
+      "type": "object",
+      "description": "Optional, repository information",
+      "required": [
+        "branch"
+      ],
+      "properties": {
+        "repo": {
+          "type": "string",
+          "description": "Optional, short repository address"
+        },
+        "branch": {
+          "type": "string",
+          "description": "Required, repository branch",
+          "default": "main"
+        },
+        "release": {
+          "type": "object",
+          "required": [
+            "tag"
+          ],
+          "properties": {
+            "tag": {
+              "type": "string",
+              "description": "Required, tag name, not recommended to write latest",
+              "default": "0.1.0"
+            },
+            "url": {
+              "type": "string",
+              "description": "Optional, filename within release, if not provided, the source code of the tag will be downloaded"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/manifest-zh.schema.json
+++ b/manifest-zh.schema.json
@@ -1,0 +1,154 @@
+{
+  "type": "object",
+  "title": "LiteLoader QQ NT Manifest Schema",
+  "description": "Json schema for LiteLoader QQ NT manifest.json.",
+  "required": [
+    "manifest_version",
+    "name",
+    "slug",
+    "description",
+    "version",
+    "authors",
+    "platform"
+  ],
+  "properties": {
+    "manifest_version": {
+      "type": "integer",
+      "description": "必填, 当前版本为4",
+      "enum": [4],
+      "default": 4
+    },
+    "type": {
+      "type": "string",
+      "description": "可选，插件类型，可写 extension | theme | framework",
+      "enum": ["extension", "theme", "framework"]
+    },
+    "name": {
+      "type": "string",
+      "description": "必选，插件名字"
+    },
+    "slug": {
+      "type": "string",
+      "description": "必选，代码内标识"
+    },
+    "description": {
+      "type": "string",
+      "description": "必选，插件描述"
+    },
+    "version": {
+      "type": "string",
+      "description": "必选，版本号"
+    },
+    "icon": {
+      "description": "可选，插件图标",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "thumb": {
+      "description": "可选，设置选项的图标，写入相对路径字符串",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "authors": {
+      "type": "array",
+      "description": "必选，作者信息",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "link"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "必选, 作者名字"
+          },
+          "link": {
+            "type": "string",
+            "description": "必选, 作者主页"
+          }
+        }
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "description": "可选，插件依赖项，写入插件slug名",
+      "items": {
+        "type": "string"
+      }
+    },
+    "platform": {
+      "type": "array",
+      "description": "必选，插件支持的系统平台，Windows: win32 | Linux: linux | MacOS: darwin",
+      "items": {
+        "type": "string",
+        "enum": ["win32", "linux", "darwin"]
+      }
+    },
+    "injects": {
+      "type": "object",
+      "description": "可选，要注入的脚本",
+      "properties": {
+        "renderer": {
+          "type": "string",
+          "description": "可选，渲染进程注入脚本"
+        },
+        "main": {
+          "type": "string",
+          "description": "可选，主进程注入脚本"
+        },
+        "preload": {
+          "type": "string",
+          "description": "可选，preload注入脚本"
+        }
+      }
+    },
+    "repository": {
+      "type": "object",
+      "description": "可选，插件仓库信息",
+      "required": [
+        "branch"
+      ],
+      "properties": {
+        "repo": {
+          "type": "string",
+          "description": "可选，仓库短地址"
+        },
+        "branch": {
+          "type": "string",
+          "description": "必选，仓库分支",
+          "default": "main"
+        },
+        "release": {
+          "type": "object",
+          "required": [
+            "tag"
+          ],
+          "properties": {
+            "tag": {
+              "type": "string",
+              "description": "必选，tag名称，不推荐写latest",
+              "default": "0.1.0"
+            },
+            "url": {
+              "type": "string",
+              "description": "可选，release内文件名，不填写会直接下载tag的源码"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
中英双语两个版本。让开发者在写manifest.json的时候无需老是查阅文档，只需要在manifest.json开头引入：

```json
{
  "$schema": "https://cdn.jsdelivr.net/gh/LiteLoaderQQNT/LiteLoaderQQNT@latest/manifest-en.schema.json"
}
```

就可以获取编辑器内的提示了：

<div align="center">
<img width="528" alt="image" src="https://github.com/user-attachments/assets/8544c41c-2382-431a-9970-e8cb5dee39c0" />
<img width="418" alt="image" src="https://github.com/user-attachments/assets/f37d5be3-7af1-40f2-b7c6-41dc438214f2" />
</div>
