### PR TITLE
feat: Experimental support for ESM syntax in main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,71 @@
 # LiteLoaderQQNT
 
-#### 轻量 · 简洁 · 开源 · 福瑞 
-
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![GitHub release](https://img.shields.io/github/v/release/LiteLoaderQQNT/LiteLoaderQQNT?logo=github)](https://github.com/LiteLoaderQQNT/LiteLoaderQQNT/releases)
 [![Follow on Telegram](https://img.shields.io/badge/Follow-Telegram-blue?logo=telegram)](https://t.me/LiteLoaderQQNT_Channel)
 
+> 轻量 · 简洁 · 开源 · 福瑞
+
 **简体中文** | [English](https://github.com/LiteLoaderQQNT/LiteLoaderQQNT/blob/main/README_EN.md)
 
+LiteLoaderQQNT 是 QQNT 的插件加载器，一般在 QQNT 的环境内简称为 LiteLoader。它可以让你自由地为 QQNT 添加各种插件，实现美化主题、增加功能等各种功能。详情查看 LiteLoaderQQNT 官网：<https://liteloaderqqnt.github.io>。
 
-LiteLoaderQQNT 是 QQNT 的插件加载器，一般在 QQNT 的环境内简称为 LiteLoader。  
-它可以让你自由地为 QQNT 添加各种插件，实现美化主题、增加功能等各种功能。
+> [!CAUTION]
+> QQ 安全中心可能会将 LiteLoaderQQNT 当作外挂软件并下线您的设备，还有可能会导致您的 QQ 账号被封禁，建议使用小号安装 LiteLoaderQQNT（目前已有人收到 QQ 安全账号的提醒）。请谨慎使用 LiteLoaderQQNT。
 
+## 安装
 
-⚠警告：QQ 安全中心可能会将 LiteLoaderQQNT 当作外挂软件并下线您的设备，还有可能会导致您的 QQ 账号封号，建议使用小号安装 LiteLoaderQQNT（目前已有人收到 QQ 安全账号的提醒）。
-请谨慎使用 LiteLoaderQQNT。
+> [!NOTE]
+> 此文档为 LiteLoaderQQNT 1.2.4 编写。目前版本暂时仅支持 Windows 64 位，需搭配频道内未公开的 `dbghelp.dll` 方可使用。
 
-详情查看 LiteLoaderQQNT 官网：https://liteloaderqqnt.github.io
+### 下载 LiteLoaderQQNT 本体
 
-# 安装
-⚠️此文档为 LiteLoaderQQNT 1.2.4 编写。目前版本暂时仅支持 Windows 64 位，需搭配频道内未公开的 `dbghelp.dll` 方可使用。
-
-### 下载 LiteLoaderQQNT 本体 
 你需要先下载 LiteLoaderQQNT 到任意位置，以下有两种方式：
 
-- Release （稳定版）：前往 [Release](https://github.com/LiteLoaderQQNT/LiteLoaderQQNT/releases) 页，下载 `LiteLoaderQQNT.zip` 文件解压到任意位置
+- Release （稳定版）：前往 [Release](https://github.com/LiteLoaderQQNT/LiteLoaderQQNT/releases) 页，下载 `LiteLoaderQQNT.zip` 文件解压到任意位置。
+- Clone （最新提交）：使用 Git 工具将 LiteLoaderQQNT 仓库 Clone 到本地任意位置。
 
-- Clone （最新提交）：使用 Git 工具将 LiteLoaderQQNT 仓库 Clone 到本地任意位置
-
-```bash
-git clone --depth 1 https://github.com/LiteLoaderQQNT/LiteLoaderQQNT.git
-```
+    ```bash
+    git clone --depth 1 https://github.com/LiteLoaderQQNT/LiteLoaderQQNT.git
+    ```
 
 ### 在 Windows 上绕过 QQNT 文件校验
+
 请根据你的操作系统架构在 Telegram 群内下载 `dbghelp_*.dll` 文件，将其重命名为 `dbghelp.dll` 后放入 `QQ.exe` 同级目录下。
 
 ### 检查是否安装成功
 
-按照上述教程完成安装后，有两种方法检查 LiteLoaderQQNT 是否成功安装
+按照上述教程完成安装后，有两种方法检查 LiteLoaderQQNT 是否成功安装：
 
 - 运行 QQNT 并打开设置，查看左侧列表是否出现 LiteLoaderQQNT 选项
-
 - 使用终端运行 QQNT 查看是否有 LiteLoaderQQNT 相关内容输出显示
 
 如果有显示，即安装成功，玩的开心！
 
-# 插件
+## 插件
 
 ### 正常操作
+
 在设置界面即可看到安装/卸载插件功能；也可以使用社区开发的插件市场类插件（例如 [plugin-list-viewer](https://github.com/ltxhhz/LL-plugin-list-viewer)），在其中进行操作。
 
 ### 手动操作
+
 将插件目录移动到 `LiteLoaderQQNT/plugins` 文件夹内以安装，在 `plugins` 目录中删除对应目录以卸载（插件数据在 `data` 目录下对应目录）。
 
 ### 寻找
-可以通过官网首页、第三方插件市场、GitHub 搜索等方式寻找插件。
 
-官方维护着一份插件列表，收录了已知的大部分插件，可在官网首页中查看详情。此外，还有一份 [json 格式的插件列表](https://github.com/LiteLoaderQQNT/Plugin-List/blob/v4/plugins.json)。
+可以通过以下方式寻找插件：
 
-# 开发
+- 官网首页
+- 第三方插件市场
+- GitHub 搜索
+
+官方维护着一份插件列表，收录了已知的大部分插件，可在官网首页中查看详情。此外，还有一份 [JSON 格式的插件列表](https://github.com/LiteLoaderQQNT/Plugin-List/blob/v4/plugins.json)。
+
+## 开发
+
 详见[官方文档](https://liteloaderqqnt.github.io/docs/introduction.html)。
 
-# 许可证
-LiteLoaderQQNT 采用 MIT 许可证进行开源。
+## 许可证
 
-```
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-```
+LiteLoaderQQNT 采用 [MIT 许可证](./LICENSE) 进行开源。

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,72 +1,71 @@
-# LiteLoaderQQNT  
+# LiteLoaderQQNT
 
-#### Lightweight · Simple · Open Source · Furry  
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![GitHub release](https://img.shields.io/github/v/release/LiteLoaderQQNT/LiteLoaderQQNT?logo=github)](https://github.com/LiteLoaderQQNT/LiteLoaderQQNT/releases)
+[![Follow on Telegram](https://img.shields.io/badge/Follow-Telegram-blue?logo=telegram)](https://t.me/LiteLoaderQQNT_Channel)
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)  [![GitHub release](https://img.shields.io/github/v/release/LiteLoaderQQNT/LiteLoaderQQNT?logo=github)](https://github.com/LiteLoaderQQNT/LiteLoaderQQNT/releases)  [![Follow on Telegram](https://img.shields.io/badge/Follow-Telegram-blue?logo=telegram)](https://t.me/LiteLoaderQQNT_Channel)  
+> Lightweight · Simple · Open Source · Furry
 
 [简体中文](https://github.com/LiteLoaderQQNT/LiteLoaderQQNT/blob/main/README.md) | **English**
 
-LiteLoaderQQNT is a plugin loader for QQNT, often referred to simply as LiteLoader within the QQNT environment.  
-It allows you to freely add various plugins to QQNT, enabling features such as theme customization, functionality enhancements, and more.  
+LiteLoaderQQNT is a plugin loader for QQNT, often referred to simply as LiteLoader within the QQNT environment. It allows you to freely add various plugins to QQNT, enabling features such as theme customization, functionality enhancements, and more. For more details, visit LiteLoaderQQNT website at <https://liteloaderqqnt.github.io>.
 
-⚠ **Warning**: QQ Security Center may flag LiteLoaderQQNT as third-party software and restrict your device access, or even result in account suspension. It is recommended to use a secondary account when installing LiteLoaderQQNT (some users have already received warnings from QQ Security).  
-Please use LiteLoaderQQNT with caution.  
+> [!CAUTION]
+> QQ Security Center may flag LiteLoaderQQNT as third-party software and restrict your device access, or even result in account suspension. It is recommended to use a secondary account when installing LiteLoaderQQNT (some users have already received warnings from QQ Security). Please use LiteLoaderQQNT with caution.
 
-For more details, visit: [https://liteloaderqqnt.github.io](https://liteloaderqqnt.github.io)  
+## Installation
 
-# Installation  
+> [!NOTE]
+> This documentation is written for LiteLoaderQQNT 1.2.4. Currently, it only supports Windows 64-bit and requires an unreleased `dbghelp.dll` from the Telegram channel.
 
-⚠️ This documentation is written for LiteLoaderQQNT 1.2.4. Currently, it only supports Windows 64-bit and requires an unreleased `dbghelp.dll` from the Telegram channel.  
+### Download LiteLoaderQQNT
 
-### Download LiteLoaderQQNT  
-First, download LiteLoaderQQNT to any location. There are two methods:  
+First, download LiteLoaderQQNT to any location. There are two methods:
 
-- **Release (Stable Version)**: Go to the [LiteLoaderQQNT Releases page](https://github.com/LiteLoaderQQNT/LiteLoaderQQNT/releases), download the `LiteLoaderQQNT.zip` file, and extract it to any location.  
-
+- **Release (Stable Version)**: Go to the [LiteLoaderQQNT Releases page](https://github.com/LiteLoaderQQNT/LiteLoaderQQNT/releases), download the `LiteLoaderQQNT.zip` file, and extract it to any location.
 - **Clone (Latest Commit)**: Use Git to clone the LiteLoaderQQNT repository locally.
 
-  ```bash
-  git clone --depth 1 https://github.com/LiteLoaderQQNT/LiteLoaderQQNT.git
-  ```  
+    ```bash
+    git clone --depth 1 https://github.com/LiteLoaderQQNT/LiteLoaderQQNT.git
+    ```
 
-### Bypassing QQNT File Verification on Windows  
-Download the `dbghelp_*.dll` file from the Telegram group according to your system architecture, rename it to `dbghelp.dll`, and place it in the same directory as `QQ.exe`.  
+### Bypassing QQNT File Verification on Windows
 
-### Verifying Installation  
-After completing the installation steps, there are two ways to check if LiteLoaderQQNT was installed successfully:  
+Download the `dbghelp_*.dll` file from the Telegram group according to your system architecture, rename it to `dbghelp.dll`, and place it in the same directory as `QQ.exe`.
 
-- Launch QQNT, open Settings, and check if the LiteLoaderQQNT option appears in the left sidebar.  
-- Run QQNT via the terminal and check if LiteLoaderQQNT-related output is displayed.  
+### Verifying Installation
 
-If either condition is met, the installation was successful. Enjoy!  
+After completing the installation steps, there are two ways to check if LiteLoaderQQNT was installed successfully:
 
-# Plugins  
+- Launch QQNT, open Settings, and check if the LiteLoaderQQNT option appears in the left sidebar.
+- Run QQNT via the terminal and check if LiteLoaderQQNT-related output is displayed.
 
-### Standard Installation  
-You can install/uninstall plugins directly in the Settings interface. Alternatively, use community-developed plugin market plugins (e.g., [plugin-list-viewer](https://github.com/ltxhhz/LL-plugin-list-viewer)) for management.  
+If either condition is met, the installation was successful. Enjoy!
 
-### Manual Installation  
-Move the plugin folder to `LiteLoaderQQNT/plugins` to install it. To uninstall, delete the corresponding folder from the `plugins` directory (plugin data is stored in the `data` directory under the same name).  
+## Plugins
 
-### Finding Plugins  
-You can discover plugins through:  
-- The official website homepage  
-- Third-party plugin markets  
-- GitHub searches  
+### Standard Installation
 
-An official [plugin list](https://github.com/LiteLoaderQQNT/Plugin-List/blob/v4/plugins.json) is maintained, cataloging most known plugins.  
+You can install/uninstall plugins directly in the Settings interface. Alternatively, use community-developed plugin market plugins (e.g., [plugin-list-viewer](https://github.com/ltxhhz/LL-plugin-list-viewer)) for management.
 
-# Development  
-Refer to the [official documentation](https://liteloaderqqnt.github.io/docs/introduction.html) for details.  
+### Manual Installation
 
-# License
-LiteLoaderQQNT is open-sourced under the MIT License.  
+Move the plugin folder to `LiteLoaderQQNT/plugins` to install it. To uninstall, delete the corresponding folder from the `plugins` directory (plugin data is stored in the `data` directory under the same name).
 
-```  
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS  
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR  
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER  
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN  
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  
-```
+### Finding Plugins
+
+You can discover plugins through:
+
+- The official website homepage
+- Third-party plugin markets
+- GitHub searches
+
+An official plugin list is maintained, cataloging most known plugins, which can be viewed on the website. Also, there's a [plugin list in JSON format](https://github.com/LiteLoaderQQNT/Plugin-List/blob/v4/plugins.json).
+
+## Development
+
+Refer to the [official documentation](https://liteloaderqqnt.github.io/docs/introduction.html) for details.
+
+## License
+
+LiteLoaderQQNT is open-sourced under [the MIT License](./LICENSE).

--- a/src/liteloader_api/main.js
+++ b/src/liteloader_api/main.js
@@ -151,23 +151,26 @@ const LiteLoader = {
 
 
 // 将LiteLoader对象挂载到全局
-const whitelist = [
+const whitelist = new Set([
     LiteLoader.path.root,
     LiteLoader.path.profile,
     LiteLoader.path.data,
     LiteLoader.path.plugins,
-];
+]);
 try {
-    whitelist.push(fs.realpathSync(LiteLoader.path.root));
-    whitelist.push(fs.realpathSync(LiteLoader.path.profile));
-    whitelist.push(fs.realpathSync(LiteLoader.path.plugins));
-    whitelist.push(fs.realpathSync(LiteLoader.path.data));
+    whitelist.add(fs.realpathSync(LiteLoader.path.root));
+    whitelist.add(fs.realpathSync(LiteLoader.path.profile));
+    whitelist.add(fs.realpathSync(LiteLoader.path.plugins));
+    whitelist.add(fs.realpathSync(LiteLoader.path.data));
 } catch { };
+whitelist.values().forEach(item => {
+    whitelist.add(item.replaceAll("\\", "/"));
+});
 Object.defineProperty(globalThis, "LiteLoader", {
     configurable: false,
     get() {
         const stack = new Error().stack.split("\n")[2];
-        if (whitelist.some(item => stack.includes(item))) {
+        if (whitelist.values().some(item => stack.includes(item))) {
             return LiteLoader;
         }
     }

--- a/src/loader_core/main.js
+++ b/src/loader_core/main.js
@@ -1,3 +1,5 @@
+const error = (...args) => console.error("\x1b[32m%s\x1b[0m", "[LiteLoader]", ...args);
+
 function topologicalSort(dependencies) {
     const sorted = [];
     const visited = new Set();
@@ -26,9 +28,22 @@ exports.MainLoader = class {
             }
             if (plugin.path.injects.main) {
                 try {
-                    this.#exports[slug] = require(plugin.path.injects.main);
+                    if (plugin.manifest.esm) {
+                        this.#exports[slug] = {};
+                        // FIXME: Async and delayed loading might cause errors for dependencies
+                        // TODO: Proper escaping?
+                        import("file:///" + plugin.path.injects.main).then((exported) => {
+                            this.#exports[slug] = exported;
+                        }).catch((e) => {
+                            error(`Error loading ${plugin.manifest.name}:`, e);
+                            plugin.error = { message: `[Main] ${e.message}`, stack: e.stack };
+                        });
+                    } else {
+                        this.#exports[slug] = require(plugin.path.injects.main);
+                    }
                 }
                 catch (e) {
+                    error(`Error loading ${plugin.manifest.name}:`, e);
                     plugin.error = { message: `[Main] ${e.message}`, stack: e.stack };
                 }
             }

--- a/src/loader_core/main.js
+++ b/src/loader_core/main.js
@@ -1,3 +1,4 @@
+const { pathToFileURL } = require("url");
 const error = (...args) => console.error("\x1b[32m%s\x1b[0m", "[LiteLoader]", ...args);
 
 function topologicalSort(dependencies) {
@@ -31,8 +32,7 @@ exports.MainLoader = class {
                     if (plugin.manifest.esm) {
                         this.#exports[slug] = {};
                         // FIXME: Async and delayed loading might cause errors for dependencies
-                        // TODO: Proper escaping?
-                        import("file:///" + plugin.path.injects.main).then((exported) => {
+                        import(pathToFileURL(plugin.path.injects.main)).then((exported) => {
                             this.#exports[slug] = exported;
                         }).catch((e) => {
                             error(`Error loading ${plugin.manifest.name}:`, e);


### PR DESCRIPTION
Notes:

- Set `esm` to `true` in `manifest.json` to enable this feature.
- ESM plugins may not work with weired paths, but CJS plugins will work regardless.

Screenshot:

<img width="3198" height="1850" alt="image" src="https://github.com/user-attachments/assets/9af5aacd-088e-44ed-8e2e-c00e108b3dbf" />
